### PR TITLE
removed args for autoOrient

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,12 +128,11 @@ ImageMagick.prototype = {
   /**
    * Sets the `auto-orient` option
    *
-   * @param {String} args
    * @api public
    */
   
-  autoOrient: function (args) {
-    this.args.push('-auto-orient', args);
+  autoOrient: function () {
+    this.args.push('-auto-orient');
     return this;
   },
   


### PR DESCRIPTION
This options doesn't take an argument.
I removed it, otherwise it leads to an useless parameter "undefined" that may cause problems
