### PR TITLE
Bump duplexify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "./node_modules/.bin/mocha --reporter spec"
   },
   "dependencies": {
-    "duplexify": "3.4.2"
+    "duplexify": "^3.4.5"
   },
   "devDependencies": {
     "mocha": "~1.18.2"


### PR DESCRIPTION
`imagemagick-stream` currently crashes with `node@6.3.0`

With `node@6.3.0` an [issue](https://github.com/mafintosh/duplexify/issues/6) appeared in duplexify.
Version `3.4.5` fixes it.

```sh
TypeError: Cannot read property 'length' of undefined
    at ImageMagick.Duplexify._forward (/code/node_modules/imagemagick-stream/node_modules/duplexify/index.js:161:76)
    at Socket.onreadable (/code/node_modules/imagemagick-stream/node_modules/duplexify/index.js:126:10)
    at emitNone (events.js:86:13)
    at Socket.emit (events.js:185:7)
    at emitReadable_ (_stream_readable.js:433:10)
    at emitReadable (_stream_readable.js:427:7)
    at readableAddChunk (_stream_readable.js:188:13)
    at Socket.Readable.push (_stream_readable.js:135:10)
    at Pipe.onread (net.js:542:20)
```