### PR TITLE
add "composite" operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,18 @@ class ImageMagick extends Duplexify {
    }
 
    /**
+    * Sets the `composite` option
+    *
+    * @param {String} otherImagePath
+    * @api public
+    */
+
+   composite(otherImagePath) {
+     this[operators].unshift(otherImagePath, '-composite');
+     return this;
+   }
+
+   /**
     * Sets the `append` option
     *
     * @param {Boolean} args

--- a/test/index.js
+++ b/test/index.js
@@ -282,4 +282,18 @@ describe('im()', function () {
       assert(args[5] == '-');
     });
   });
+
+  describe('.composite()', function() {
+    it('should set "-composite" option', function() {
+      var img = im();
+      var imgToComp = __dirname + '/composite-image.png';
+      img.composite(imgToComp);
+
+      var args = img.args();
+      assert(args[0] === '-');
+      assert(args[1] === imgToComp);
+      assert(args[2] === '-composite');
+      assert(args[3] === '-');
+    });
+  });
 });


### PR DESCRIPTION
Hi @eivindfjeldstad, 

the commits are squashed.

This PR adds a new operator "-composite" so that the lib can do things with imagemagick like 
```
convert - imageToBeComposited.png -composite -
```

The difference about this operator is that the argument is added before it. The argument is the path of the image which should be composited on top of the image from input stream. 

Best regards,