### PR TITLE
Increase spawn buffer size limit to one gigabyte

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ class ImageMagick extends Duplexify {
 
    spawn () {
      const onerror = this.onerror.bind(this);
-     const proc = spawn('convert', this.args());
+     const proc = spawn('convert', this.args(), {maxBuffer: 1024 * 1024 * 1024});
 
      const stdout = proc.stdout;
      stdout.on('error', onerror);


### PR DESCRIPTION
This solved an issue where streams were capped to 200Kb on my system. Running Ubuntu 20.04.2 LTS