### PR TITLE
Allow '+' options

### DIFF
--- a/index.js
+++ b/index.js
@@ -202,7 +202,9 @@ class ImageMagick extends Duplexify {
     */
 
    set (key, val) {
-     this[settings].push(`-${key}`);
+     const isPlusOp = /^\+/.test(key);
+     const flag = isPlusOp ? key : `-${key}`;
+     this[settings].push(flag);
      if (val == null) return this;
      if (!Array.isArray(val)) val = [val];
      val.forEach(v => this[settings].push(v));
@@ -218,7 +220,9 @@ class ImageMagick extends Duplexify {
     */
 
    op (key, val) {
-     this[operators].push(`-${key}`);
+     const isPlusOp = /^\+/.test(key);
+     const flag = isPlusOp ? key : `-${key}`;
+     this[operators].push(flag);
      if (val == null) return this;
      if (!Array.isArray(val)) val = [val];
      val.forEach(v => this[operators].push(v));

--- a/test/index.js
+++ b/test/index.js
@@ -241,6 +241,14 @@ describe('im()', function () {
       assert(args[2] == '0');
       assert(args[3] == "'text'");
     });
+
+    it('should use + instead of - for flag if provided', function () {
+      var img = im();
+      img.op('+repage');
+
+      var args = img.args();
+      assert(args[1] == '+repage');
+    })
   });
 
   describe('.set()', function() {
@@ -281,5 +289,13 @@ describe('im()', function () {
       assert(args[4] == 0.05);
       assert(args[5] == '-');
     });
+
+    it('should use + instead of - for flag if provided', function () {
+      var img = im();
+      img.set('+repage');
+
+      var args = img.args();
+      assert(args[0] == '+repage');
+    })
   });
 });


### PR DESCRIPTION
For settings and operations, if key starts with `+`, use that for the flag instead of adding a `-` sign in front.

Resolves #33 